### PR TITLE
Adding github actions option

### DIFF
--- a/.github/workflows/build_publish_manifests.yml
+++ b/.github/workflows/build_publish_manifests.yml
@@ -1,0 +1,55 @@
+on:
+  push:
+    branches:
+      - main
+      - master
+  
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  FabrikateToManifest:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download Bedrock orchestration script
+        run: |
+          curl $BEDROCK_BUILD_SCRIPT > build.sh
+          chmod +x ./build.sh
+        shell: bash
+        env:
+          BEDROCK_BUILD_SCRIPT: https://raw.githubusercontent.com/Microsoft/bedrock/master/gitops/azure-devops/build.sh
+
+      - uses: azure/setup-helm@v1
+        with:
+          version: '2.17.0' # 2.17.0 is the first version that uses the updated charts repositories
+        id: install
+
+      - name: Validate fabrikate definitions
+        run: |
+          chmod +x ./build.sh
+          ./build.sh
+        shell: bash
+        env:
+          MAJOR: 1
+          VERIFY_ONLY: 1
+
+      - name: Get current branch name
+        run: |
+          echo "::set-output name=branch_name::${GITHUB_REF#refs/heads/}"
+        shell: bash
+        id: get_branch_name
+
+      - name: Transform fabrikate definitions and publish to YAML manifests to repo
+        run: |
+          ./build.sh
+        shell: bash
+        env:
+          MAJOR: 1
+          ACCESS_TOKEN_SECRET: ${{ secrets.ACCESS_TOKEN }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          REPO: ${{ secrets.MANIFEST_REPO }}
+          BRANCH_NAME: ${{ steps.get_branch_name.outputs.branch_name }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,10 @@ steps:
   env:
     BEDROCK_BUILD_SCRIPT: https://raw.githubusercontent.com/Microsoft/bedrock/master/gitops/azure-devops/build.sh
 
+- task: HelmInstaller@1
+  inputs:
+    helmVersionToInstall: '2.17.0' # 2.17.0 is the first version that uses the updated charts repositories
+
 - task: ShellScript@2
   displayName: Validate fabrikate definitions
   inputs:

--- a/component.yaml
+++ b/component.yaml
@@ -5,6 +5,6 @@ subcomponents:
 - name: services
   source: "./services"
 - name: "cloud-native"
-  source: "https://github.com/timfpark/fabrikate-cloud-native"
-  branch: "master"
+  source: "https://github.com/eladiw/fabrikate-cloud-native"
+  branch: "feature/update-jaeger"
   method: "git"


### PR DESCRIPTION
Adding Github actions support.

1. using Helm 2.17 explicitly as the build script is using helm v2. 
2. helm must be 2.17 as this is the only v2 version that uses the up to date charts repositories.
3. the fabrikate-cloud-native used is a fork, as the main version is currently broken